### PR TITLE
feat: check is mock prop using property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ This is useful when you want to mock properties in certain test cases and restor
 
 The jest object needs to be extended in every test file. This allows mocked properties to be reset and restored with [`jest.resetAllMocks`](https://jestjs.io/docs/en/jest-object#jestresetallmocks) and [`jest.restoreAllMocks`](https://jestjs.io/docs/en/jest-object#jestrestoreallmocks) respectively.
 
-#### `jest.isMockProp(prop)`
+#### `jest.isMockProp(object, propertyName)`
 
-Determines if the given object is a mocked property.
+Determines if the given object property has been mocked.
 
 #### `jest.spyOnProp(object, propertyName)`
 

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -12,7 +12,7 @@ declare interface MockProp {
 
 // tslint:disable-next-line no-namespace
 declare namespace jest {
-    const isMockProp: (object: any) => boolean;
+    const isMockProp: (object: any, propName?: string) => boolean;
     const spyOnProp: (object: AnyObject, propName: string) => MockProp;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,7 @@ class MockProp implements MockProp {
             try {
                 delete this.object[this.propName];
             } catch (error) {
-                if (error instanceof TypeError) {
-                    this.object[this.propName] = undefined;
-                } else {
-                    throw error;
-                }
+                this.object[this.propName] = undefined;
             }
         }
         if (this.initialPropValue !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
-const messages = {
+export const messages = {
     error: {
         noMethodSpy: "Can not spy on method. Please use `jest.spyOn`",
     },
+    warn: {
+        noIsMockPropValue: `Checking \`isMockProp\` using value is deprecated.
+Please use \`jest.isMockProp(object, propName)\``,
+    },
 };
+
+export const log = (...args: any[]) => log.default(...args);
+log.default = log.warn = (...args: any[]) => console.warn(...args); // tslint:disable-line
 
 const spies: Set<MockProp> = new Set();
 const spiedOn: Map<object, Set<string>> = new Map();
@@ -100,12 +107,15 @@ class MockProp implements MockProp {
     }
 }
 
-const isMockProp = (object: any, propName?: string): boolean =>
-    Boolean(
-        propName
-            ? spiedOn.get(object) && spiedOn.get(object).has(propName)
-            : object && object.mock instanceof MockProp,
-    );
+const isMockProp = (object: any, propName?: string): boolean => {
+    if (propName) {
+        return Boolean(
+            spiedOn.get(object) && spiedOn.get(object).has(propName),
+        );
+    }
+    log.warn(messages.warn.noIsMockPropValue);
+    return Boolean(object && object.mock instanceof MockProp);
+};
 
 const resetAll = (): void => spies.forEach(spy => spy.mockReset());
 const restoreAll = (): void => spies.forEach(spy => spy.mockRestore());

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -11,18 +11,31 @@ const mockObject: AnyObject = {
 
 beforeAll(() => mockProps.extend(jest));
 
+const expectIsMockProp = (
+    object: AnyObject,
+    propName: string,
+    value = true,
+) => {
+    expect(jest.isMockProp(object, propName)).toBe(value);
+    expect(jest.isMockProp(object[propName])).toBe(value);
+};
+const expectIsNotMockProp = (object: AnyObject, propName: string) =>
+    expectIsMockProp(object, propName, false);
+
 it("mocks object undefined property", () => {
     const testObject: AnyObject = {};
-    const spy = jest.spyOnProp(testObject, "propUndefined");
-    expect(testObject.propUndefined).toEqual(undefined);
+    const spy = jest.spyOnProp(testObject, "propUndefined").mockValue(1);
+    expect(testObject.propUndefined).toEqual(1);
+    expect(jest.isMockProp(testObject, "propUndefined")).toBe(true);
     spy.mockRestore();
     expect(testObject.propUndefined).toEqual(undefined);
 });
 
 it("mocks object null property", () => {
     const testObject: AnyObject = { propNull: null };
-    const spy = jest.spyOnProp(testObject, "propNull");
-    expect(testObject.propNull).toEqual(null);
+    const spy = jest.spyOnProp(testObject, "propNull").mockValue(2);
+    expect(testObject.propNull).toEqual(2);
+    expect(jest.isMockProp(testObject, "propNull")).toBe(true);
     spy.mockRestore();
     expect(testObject.propNull).toEqual(null);
 });
@@ -35,7 +48,8 @@ it("mocks object property value", () => {
     spy.mockValue(mockValue);
     expect(testObject.prop1).toEqual(mockValue);
     expect(testObject.prop1).toEqual(mockValue);
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
+    expectIsMockProp(testObject, "prop1");
+    spy.mockRestore();
 });
 
 it("mocks object property value once", () => {
@@ -54,10 +68,10 @@ it("resets mocked object property", () => {
     const mockValue = 99;
     const spy = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
     expect(testObject.prop1).toEqual(mockValue);
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
+    expectIsMockProp(testObject, "prop1");
     spy.mockReset();
     expect(testObject.prop1).toEqual("1");
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
+    expectIsMockProp(testObject, "prop1");
 });
 
 it("restores mocked object property", () => {
@@ -65,10 +79,10 @@ it("restores mocked object property", () => {
     const mockValue = 99;
     const spy = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
     expect(testObject.prop1).toEqual(mockValue);
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
+    expectIsMockProp(testObject, "prop1");
     spy.mockRestore();
     expect(testObject.prop1).toEqual("1");
-    expect(jest.isMockProp(testObject.prop1)).toBe(false);
+    expectIsNotMockProp(testObject, "prop1");
 });
 
 it("resets mocked object property in jest.resetAllMocks", () => {
@@ -79,13 +93,11 @@ it("resets mocked object property in jest.resetAllMocks", () => {
     jest.spyOnProp(testObject, "prop2").mockValue(mockValue2);
     expect(testObject.prop1).toEqual(mockValue1);
     expect(testObject.prop2).toEqual(mockValue2);
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
-    expect(jest.isMockProp(testObject.prop2)).toBe(true);
+    expectIsMockProp(testObject, "prop2");
     jest.resetAllMocks();
     expect(testObject.prop1).toEqual("1");
     expect(testObject.prop2).toEqual(2);
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
-    expect(jest.isMockProp(testObject.prop2)).toBe(true);
+    expectIsMockProp(testObject, "prop2");
 });
 
 it("restores mocked object property in jest.restoreAllMocks", () => {
@@ -96,20 +108,20 @@ it("restores mocked object property in jest.restoreAllMocks", () => {
     jest.spyOnProp(testObject, "prop2").mockValue(mockValue2);
     expect(testObject.prop1).toEqual(mockValue1);
     expect(testObject.prop2).toEqual(mockValue2);
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
-    expect(jest.isMockProp(testObject.prop2)).toBe(true);
+    expectIsMockProp(testObject, "prop1");
+    expectIsMockProp(testObject, "prop2");
     jest.restoreAllMocks();
     expect(testObject.prop1).toEqual("1");
     expect(testObject.prop2).toEqual(2);
-    expect(jest.isMockProp(testObject.prop1)).toBe(false);
-    expect(jest.isMockProp(testObject.prop2)).toBe(false);
+    expectIsNotMockProp(testObject, "prop1");
+    expectIsNotMockProp(testObject, "prop2");
 });
 
 it("does not mock object method", () => {
     expect(() =>
         jest.spyOnProp(mockObject, "fn1"),
     ).toThrowErrorMatchingSnapshot();
-    expect(jest.isMockProp(mockObject.fn1)).toBe(false);
+    expectIsNotMockProp(mockObject, "fn1");
     expect(mockObject.fn1()).toEqual("fnReturnValue");
 });
 
@@ -117,7 +129,7 @@ it("does not mock object getter", () => {
     expect(() =>
         jest.spyOnProp(mockObject, "propZ"),
     ).toThrowErrorMatchingSnapshot();
-    expect(jest.isMockProp(mockObject.propZ)).toBe(false);
+    expectIsNotMockProp(mockObject, "propZ");
     expect(mockObject.propZ).toEqual("z");
 });
 
@@ -138,6 +150,6 @@ it("does not mock object setter", () => {
 it("throws error on mockClear", () => {
     const testObject = { ...mockObject };
     const spy = jest.spyOnProp(testObject, "prop1");
-    expect(jest.isMockProp(testObject.prop1)).toBe(true);
+    expectIsMockProp(testObject, "prop1");
     expect(spy.mockClear).toThrowErrorMatchingSnapshot();
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,7 +9,16 @@ const mockObject: AnyObject = {
     },
 };
 
-beforeAll(() => mockProps.extend(jest));
+const spyConsoleWarn = jest.fn();
+const spyOnConsoleWarn = () =>
+    jest.spyOn(console, "warn").mockImplementation(spyConsoleWarn);
+
+beforeEach(jest.clearAllMocks);
+beforeAll(() => {
+    mockProps.extend(jest);
+    spyOnConsoleWarn();
+});
+afterAll(jest.restoreAllMocks);
 
 const expectIsMockProp = (
     object: AnyObject,
@@ -49,6 +58,9 @@ it("mocks object property value", () => {
     expect(testObject.prop1).toEqual(mockValue);
     expect(testObject.prop1).toEqual(mockValue);
     expectIsMockProp(testObject, "prop1");
+    expect(spyConsoleWarn).toHaveBeenCalledWith(
+        mockProps.messages.warn.noIsMockPropValue,
+    );
     spy.mockRestore();
 });
 
@@ -98,6 +110,7 @@ it("resets mocked object property in jest.resetAllMocks", () => {
     expect(testObject.prop1).toEqual("1");
     expect(testObject.prop2).toEqual(2);
     expectIsMockProp(testObject, "prop2");
+    spyOnConsoleWarn();
 });
 
 it("restores mocked object property in jest.restoreAllMocks", () => {
@@ -115,6 +128,7 @@ it("restores mocked object property in jest.restoreAllMocks", () => {
     expect(testObject.prop2).toEqual(2);
     expectIsNotMockProp(testObject, "prop1");
     expectIsNotMockProp(testObject, "prop2");
+    spyOnConsoleWarn();
 });
 
 it("does not mock object method", () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -35,6 +35,8 @@ it("mocks object undefined property", () => {
     const testObject: AnyObject = {};
     const spy = jest.spyOnProp(testObject, "propUndefined").mockValue(1);
     expect(testObject.propUndefined).toEqual(1);
+    testObject.propUndefined = 5;
+    expect(testObject.propUndefined).toEqual(5);
     expect(jest.isMockProp(testObject, "propUndefined")).toBe(true);
     spy.mockRestore();
     expect(testObject.propUndefined).toEqual(undefined);
@@ -44,6 +46,8 @@ it("mocks object null property", () => {
     const testObject: AnyObject = { propNull: null };
     const spy = jest.spyOnProp(testObject, "propNull").mockValue(2);
     expect(testObject.propNull).toEqual(2);
+    testObject.propNull = 10;
+    expect(testObject.propNull).toEqual(10);
     expect(jest.isMockProp(testObject, "propNull")).toBe(true);
     spy.mockRestore();
     expect(testObject.propNull).toEqual(null);
@@ -54,7 +58,7 @@ it("mocks object property value", () => {
     const mockValue = 99;
     const spy = jest.spyOnProp(testObject, "prop1");
     expect(testObject.prop1).toEqual("1");
-    spy.mockValue(mockValue);
+    testObject.prop1 = mockValue;
     expect(testObject.prop1).toEqual(mockValue);
     expect(testObject.prop1).toEqual(mockValue);
     expectIsMockProp(testObject, "prop1");
@@ -62,6 +66,7 @@ it("mocks object property value", () => {
         mockProps.messages.warn.noIsMockPropValue,
     );
     spy.mockRestore();
+    expect(testObject.prop1).toEqual("1");
 });
 
 it("mocks object property value once", () => {
@@ -73,6 +78,18 @@ it("mocks object property value once", () => {
     expect(testObject.prop2).toEqual(mockValue2);
     expect(testObject.prop2).toEqual(mockValue1);
     expect(testObject.prop2).toEqual(2);
+});
+
+it("mocks object property replaces once", () => {
+    const testObject = { ...mockObject };
+    const mockValue1 = 99;
+    const mockValue2 = 100;
+    const spy = jest.spyOnProp(testObject, "prop2").mockValueOnce(mockValue1);
+    spy.mockValueOnce(mockValue2);
+    expect(testObject.prop2).toEqual(mockValue2);
+    spy.mockValue(4);
+    expect(testObject.prop2).toEqual(4);
+    expect(testObject.prop2).toEqual(4);
 });
 
 it("resets mocked object property", () => {


### PR DESCRIPTION
# Description

Support checking `isMockProp` on `undefined` or `null` properties.

## Changes

- Check `isMockProp` using property name
- Deprecate `isMockProp` using value check
- Allow `undefined` properties to be reassigned

### Comments
