### PR TITLE
feat: do not spy on undefined property

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Creates a mock property attached to `object[propertyName]` and returns a mock pr
 
 ## Example
 
-### file.js
+### video.js
 
 ```js
 const video = {
@@ -78,7 +78,7 @@ const video = {
 module.exports = video;
 ```
 
-### file.test.js
+### video.test.js
 
 ```js
 import * as mockProps from "jest-mock-props";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 export const messages = {
     error: {
-        noMethodSpy: "Can not spy on method. Please use `jest.spyOn`",
+        noMethodSpy: (p: string) =>
+            `Cannot spy on the property '${p}' because it is a function. Please use \`jest.spyOn\`.`,
+        noMockClear: "Cannot `mockClear` on property spy.",
+        noUndefinedSpy: (prop: string) =>
+            `Cannot spy on the property '${prop}' because it is not defined.`,
     },
     warn: {
         noIsMockPropValue: `Checking \`isMockProp\` using value is deprecated.
@@ -37,7 +41,7 @@ class MockProp implements MockProp {
     }
 
     public mockClear = (): void => {
-        throw new Error("Nothing to clear");
+        throw new Error(messages.error.noMockClear);
     }
 
     public mockReset = (): void => {
@@ -86,13 +90,15 @@ class MockProp implements MockProp {
         propName: string;
     }): void => {
         const descriptor = Object.getOwnPropertyDescriptor(object, propName);
-        if (!descriptor) return;
+        if (!descriptor) {
+            throw new Error(messages.error.noUndefinedSpy(propName));
+        }
         if (
             descriptor.set ||
             descriptor.get ||
             descriptor.value instanceof Function
         ) {
-            throw new Error(messages.error.noMethodSpy);
+            throw new Error(messages.error.noMethodSpy(propName));
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ export const messages = {
         noMethodSpy: (p: string) =>
             `Cannot spy on the property '${p}' because it is a function. Please use \`jest.spyOn\`.`,
         noMockClear: "Cannot `mockClear` on property spy.",
-        noUndefinedSpy: (prop: string) =>
-            `Cannot spy on the property '${prop}' because it is not defined.`,
+        noUndefinedSpy: (p: string) =>
+            `Cannot spy on the property '${p}' because it is not defined.`,
     },
     warn: {
         noIsMockPropValue: `Checking \`isMockProp\` using value is deprecated.

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`does not mock object getter 1`] = `"Can not spy on method. Please use \`jest.spyOn\`"`;
+exports[`does not mock object getter 1`] = `"Cannot spy on the property 'propZ' because it is a function. Please use \`jest.spyOn\`."`;
 
-exports[`does not mock object method 1`] = `"Can not spy on method. Please use \`jest.spyOn\`"`;
+exports[`does not mock object method 1`] = `"Cannot spy on the property 'fn1' because it is a function. Please use \`jest.spyOn\`."`;
 
-exports[`does not mock object setter 1`] = `"Can not spy on method. Please use \`jest.spyOn\`"`;
+exports[`does not mock object setter 1`] = `"Cannot spy on the property 'propY' because it is a function. Please use \`jest.spyOn\`."`;
 
-exports[`throws error on mockClear 1`] = `"Nothing to clear"`;
+exports[`does not mock object undefined property 1`] = `"Cannot spy on the property 'propUndefined' because it is not defined."`;
+
+exports[`throws error on mockClear 1`] = `"Cannot \`mockClear\` on property spy."`;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -31,8 +31,8 @@ const expectIsMockProp = (
 const expectIsNotMockProp = (object: AnyObject, propName: string) =>
     expectIsMockProp(object, propName, false);
 
-it("mocks object undefined property", () => {
-    const testObject: AnyObject = {};
+it("mocks object property value undefined", () => {
+    const testObject: AnyObject = { propUndefined: undefined };
     const spy = jest.spyOnProp(testObject, "propUndefined").mockValue(1);
     expect(testObject.propUndefined).toEqual(1);
     testObject.propUndefined = 5;
@@ -42,7 +42,7 @@ it("mocks object undefined property", () => {
     expect(testObject.propUndefined).toEqual(undefined);
 });
 
-it("mocks object null property", () => {
+it("mocks object property value null", () => {
     const testObject: AnyObject = { propNull: null };
     const spy = jest.spyOnProp(testObject, "propNull").mockValue(2);
     expect(testObject.propNull).toEqual(2);
@@ -146,6 +146,14 @@ it("restores mocked object property in jest.restoreAllMocks", () => {
     expectIsNotMockProp(testObject, "prop1");
     expectIsNotMockProp(testObject, "prop2");
     spyOnConsoleWarn();
+});
+
+it("does not mock object undefined property", () => {
+    expect(() =>
+        jest.spyOnProp(mockObject, "propUndefined"),
+    ).toThrowErrorMatchingSnapshot();
+    expectIsNotMockProp(mockObject, "propUndefined");
+    expect(mockObject.propUndefined).toBeUndefined();
 });
 
 it("does not mock object method", () => {


### PR DESCRIPTION
# Description

Match `jest.spyOn` behaviour by throwing error when property spied on is undefined.

## Changes

- Do not spy on undefined property
- Documentation update

### Comments

- Addition comments for reviewers
