### PR TITLE
 feat: do not spy on unconfigurable property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 export const messages = {
     error: {
-        invalidSpy: (o: any) =>
-            `Cannot spyOn on a primitive value; '${o}' given.`,
+        invalidSpy: (o: any) => {
+            const helpfulValue = `${o ? typeof o : ""}'${o}'`;
+            return `Cannot spyOn on a primitive value; ${helpfulValue} given.`;
+        },
         noMethodSpy: (p: string) =>
             `Cannot spy on the property '${p}' because it is a function. Please use \`jest.spyOn\`.`,
         noMockClear: "Cannot `mockClear` on property spy.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export const messages = {
     error: {
+        invalidSpy: (o: any) =>
+            `Cannot spyOn on a primitive value; '${o}' given.`,
         noMethodSpy: (p: string) =>
             `Cannot spy on the property '${p}' because it is a function. Please use \`jest.spyOn\`.`,
         noMockClear: "Cannot `mockClear` on property spy.",
@@ -89,6 +91,10 @@ class MockProp implements MockProp {
         object: AnyObject;
         propName: string;
     }): void => {
+        const acceptedTypes: Set<string> = new Set(["function", "object"]);
+        if (object === null || !acceptedTypes.has(typeof object)) {
+            throw new Error(messages.error.invalidSpy(object));
+        }
         const descriptor = Object.getOwnPropertyDescriptor(object, propName);
         if (!descriptor) {
             throw new Error(messages.error.noUndefinedSpy(propName));

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export const messages = {
         noMethodSpy: (p: string) =>
             `Cannot spy on the property '${p}' because it is a function. Please use \`jest.spyOn\`.`,
         noMockClear: "Cannot `mockClear` on property spy.",
+        noUnconfigurableSpy: (p: string) =>
+            `Cannot spy on the property '${p}' because it is not configurable`,
         noUndefinedSpy: (p: string) =>
             `Cannot spy on the property '${p}' because it is not defined.`,
     },
@@ -89,6 +91,9 @@ class MockProp implements MockProp {
         const descriptor = Object.getOwnPropertyDescriptor(object, propName);
         if (!descriptor) {
             throw new Error(messages.error.noUndefinedSpy(propName));
+        }
+        if (!descriptor.configurable) {
+            throw new Error(messages.error.noUnconfigurableSpy(propName));
         }
         if (
             descriptor.set ||

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -14,6 +14,8 @@ exports[`does not mock object getter 1`] = `"Cannot spy on the property 'propZ' 
 
 exports[`does not mock object method 1`] = `"Cannot spy on the property 'fn1' because it is a function. Please use \`jest.spyOn\`."`;
 
+exports[`does not mock object non-configurable property 1`] = `"Cannot spy on the property 'propUnconfigurable' because it is not defined."`;
+
 exports[`does not mock object setter 1`] = `"Cannot spy on the property 'propY' because it is a function. Please use \`jest.spyOn\`."`;
 
 exports[`does not mock object undefined property 1`] = `"Cannot spy on the property 'propUndefined' because it is not defined."`;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`does not mock 'boolean' primitive 1`] = `"Cannot spyOn on a primitive value; 'true' given."`;
+exports[`does not mock 'boolean' primitive 1`] = `"Cannot spyOn on a primitive value; boolean'true' given."`;
 
 exports[`does not mock 'null' primitive 1`] = `"Cannot spyOn on a primitive value; 'null' given."`;
 
-exports[`does not mock 'number' primitive 1`] = `"Cannot spyOn on a primitive value; '99' given."`;
+exports[`does not mock 'number' primitive 1`] = `"Cannot spyOn on a primitive value; number'99' given."`;
 
-exports[`does not mock 'string' primitive 1`] = `"Cannot spyOn on a primitive value; 'value' given."`;
+exports[`does not mock 'string' primitive 1`] = `"Cannot spyOn on a primitive value; string'value' given."`;
 
 exports[`does not mock 'undefined' primitive 1`] = `"Cannot spyOn on a primitive value; 'undefined' given."`;
 
@@ -14,7 +14,7 @@ exports[`does not mock object getter property 1`] = `"Cannot spy on the property
 
 exports[`does not mock object method property 1`] = `"Cannot spy on the property 'fn1' because it is a function. Please use \`jest.spyOn\`."`;
 
-exports[`does not mock object non-configurable property 1`] = `"Cannot spy on the property 'propUnconfigurable' because it is not defined."`;
+exports[`does not mock object non-configurable property 1`] = `"Cannot spy on the property 'propUnconfigurable' because it is not configurable"`;
 
 exports[`does not mock object setter property 1`] = `"Cannot spy on the property 'propY' because it is a function. Please use \`jest.spyOn\`."`;
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not mock 'boolean' primitive 1`] = `"Cannot spyOn on a primitive value; 'true' given."`;
+
+exports[`does not mock 'null' primitive 1`] = `"Cannot spyOn on a primitive value; 'null' given."`;
+
+exports[`does not mock 'number' primitive 1`] = `"Cannot spyOn on a primitive value; '99' given."`;
+
+exports[`does not mock 'string' primitive 1`] = `"Cannot spyOn on a primitive value; 'value' given."`;
+
+exports[`does not mock 'undefined' primitive 1`] = `"Cannot spyOn on a primitive value; 'undefined' given."`;
+
 exports[`does not mock object getter 1`] = `"Cannot spy on the property 'propZ' because it is a function. Please use \`jest.spyOn\`."`;
 
 exports[`does not mock object method 1`] = `"Cannot spy on the property 'fn1' because it is a function. Please use \`jest.spyOn\`."`;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -10,13 +10,13 @@ exports[`does not mock 'string' primitive 1`] = `"Cannot spyOn on a primitive va
 
 exports[`does not mock 'undefined' primitive 1`] = `"Cannot spyOn on a primitive value; 'undefined' given."`;
 
-exports[`does not mock object getter 1`] = `"Cannot spy on the property 'propZ' because it is a function. Please use \`jest.spyOn\`."`;
+exports[`does not mock object getter property 1`] = `"Cannot spy on the property 'propZ' because it is a function. Please use \`jest.spyOn\`."`;
 
-exports[`does not mock object method 1`] = `"Cannot spy on the property 'fn1' because it is a function. Please use \`jest.spyOn\`."`;
+exports[`does not mock object method property 1`] = `"Cannot spy on the property 'fn1' because it is a function. Please use \`jest.spyOn\`."`;
 
 exports[`does not mock object non-configurable property 1`] = `"Cannot spy on the property 'propUnconfigurable' because it is not defined."`;
 
-exports[`does not mock object setter 1`] = `"Cannot spy on the property 'propY' because it is a function. Please use \`jest.spyOn\`."`;
+exports[`does not mock object setter property 1`] = `"Cannot spy on the property 'propY' because it is a function. Please use \`jest.spyOn\`."`;
 
 exports[`does not mock object undefined property 1`] = `"Cannot spy on the property 'propUndefined' because it is not defined."`;
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -152,10 +152,18 @@ it.each([undefined, null, 99, "value", true].map(v => [v && typeof v, v]))(
     "does not mock '%s' primitive",
     (_, v: any) => {
         expect(() =>
-            jest.spyOnProp(v, "propUndefined"),
+            jest.spyOnProp(v, "propName"),
         ).toThrowErrorMatchingSnapshot();
     },
 );
+
+it("does not mock object non-configurable property", () => {
+    const testObject: AnyObject = {};
+    Object.defineProperty(testObject, "propUnconfigurable", { value: 2 });
+    expect(() =>
+        jest.spyOnProp(mockObject, "propUnconfigurable"),
+    ).toThrowErrorMatchingSnapshot();
+});
 
 it("does not mock object undefined property", () => {
     expect(() =>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -173,7 +173,7 @@ it("does not mock object undefined property", () => {
     expect(mockObject.propUndefined).toBeUndefined();
 });
 
-it("does not mock object method", () => {
+it("does not mock object method property", () => {
     expect(() =>
         jest.spyOnProp(mockObject, "fn1"),
     ).toThrowErrorMatchingSnapshot();
@@ -181,7 +181,7 @@ it("does not mock object method", () => {
     expect(mockObject.fn1()).toEqual("fnReturnValue");
 });
 
-it("does not mock object getter", () => {
+it("does not mock object getter property", () => {
     expect(() =>
         jest.spyOnProp(mockObject, "propZ"),
     ).toThrowErrorMatchingSnapshot();
@@ -189,7 +189,7 @@ it("does not mock object getter", () => {
     expect(mockObject.propZ).toEqual("z");
 });
 
-it("does not mock object setter", () => {
+it("does not mock object setter property", () => {
     const testObject = {
         _value: 2,
         set propY(v: number) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -148,6 +148,15 @@ it("restores mocked object property in jest.restoreAllMocks", () => {
     spyOnConsoleWarn();
 });
 
+it.each([undefined, null, 99, "value", true].map(v => [v && typeof v, v]))(
+    "does not mock '%s' primitive",
+    (_, v: any) => {
+        expect(() =>
+            jest.spyOnProp(v, "propUndefined"),
+        ).toThrowErrorMatchingSnapshot();
+    },
+);
+
 it("does not mock object undefined property", () => {
     expect(() =>
         jest.spyOnProp(mockObject, "propUndefined"),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -158,10 +158,10 @@ it.each([undefined, null, 99, "value", true].map(v => [v && typeof v, v]))(
 );
 
 it("does not mock object non-configurable property", () => {
-    const testObject: AnyObject = {};
+    const testObject = {};
     Object.defineProperty(testObject, "propUnconfigurable", { value: 2 });
     expect(() =>
-        jest.spyOnProp(mockObject, "propUnconfigurable"),
+        jest.spyOnProp(testObject, "propUnconfigurable"),
     ).toThrowErrorMatchingSnapshot();
 });
 


### PR DESCRIPTION
# Description

Do not spy on unconfigurable props or primitive objects.

## Changes

- error messaging for invalid spyon targets
- use own descriptor to restore property
- do not spy on unconfigurable property
- some light refactoring of tests

### Comments

- Addition comments for reviewers
