### PR TITLE
Reuse existing spies when mocking properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Determines if the given object property has been mocked.
 
 #### `jest.spyOnProp(object, propertyName)`
 
-Creates a mock property attached to `object[propertyName]` and returns a mock property spy object, which controls all access to the object property.
+Creates a mock property attached to `object[propertyName]` and returns a mock property spy object, which controls all access to the object property. Repeating spying on the same object property will return the same mocked property spy.
 
 **Note**: By default, `spyOnProp` preserves the object property value. If you want to overwrite the original value, you can use `jest.spyOnProp(object, methodName).mockValue(customValue)` or [`jest.spyOn(object, methodName, accessType?)`](https://jestjs.io/docs/en/jest-object#jestspyonobject-methodname-accesstype) to spy on a getter or a setter.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,8 +140,7 @@ class MockProp implements MockProp {
      * Stop tracking spy
      */
     private deregister = (): void => {
-        spies.delete(this);
-        spiedOn.delete(this.object);
+        spiedOn.get(this.object).delete(this.propName);
     }
 
     /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -90,11 +90,11 @@ it("mocks object property replaces once", () => {
 it("mocks object multiple properties", () => {
     const testObject = { ...mockObject };
     const mockValue = 99;
-    const spy1 = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
+    const spy = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
     expect(testObject.prop1).toEqual(mockValue);
     jest.spyOnProp(testObject, "prop2").mockValue(mockValue);
     expect(testObject.prop2).toEqual(mockValue);
-    spy1.mockRestore();
+    spy.mockRestore();
     expect(jest.isMockProp(testObject, "prop2")).toBe(true);
     expect(testObject.prop1).toEqual("1");
     expect(testObject.prop2).toEqual(mockValue);
@@ -155,16 +155,17 @@ it("restores mocked object property in jest.restoreAllMocks", () => {
 });
 
 it("does not remock object property", () => {
-    const testObject = { ...mockObject };
+    const testObject1 = { ...mockObject };
     const mockValue = 99;
-    const spy1 = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
-    expect(testObject.prop1).toEqual(mockValue);
-    const spy2 = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
+    const spy1 = jest.spyOnProp(testObject1, "prop1").mockValue(mockValue);
+    expect(testObject1.prop1).toEqual(mockValue);
+    const testObject2 = testObject1;
+    const spy2 = jest.spyOnProp(testObject2, "prop1").mockValue(mockValue);
     expect(spy2).toBe(spy1);
-    expect(jest.isMockProp(testObject, "prop1")).toBe(true);
+    expect(jest.isMockProp(testObject2, "prop1")).toBe(true);
     spy2.mockRestore();
-    expect(testObject.prop1).toEqual("1");
-    expect(jest.isMockProp(testObject, "prop1")).toBe(false);
+    expect(testObject2.prop1).toEqual("1");
+    expect(jest.isMockProp(testObject2, "prop1")).toBe(false);
 });
 
 it.each([undefined, null, 99, "value", true].map(v => [v && typeof v, v]))(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -91,10 +91,9 @@ it("mocks object multiple properties", () => {
     const testObject = { ...mockObject };
     const mockValue = 99;
     const spy = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
-    expect(testObject.prop1).toEqual(mockValue);
     jest.spyOnProp(testObject, "prop2").mockValue(mockValue);
-    expect(testObject.prop2).toEqual(mockValue);
     spy.mockRestore();
+    expect(jest.isMockProp(testObject, "prop1")).toBe(false);
     expect(jest.isMockProp(testObject, "prop2")).toBe(true);
     expect(testObject.prop1).toEqual("1");
     expect(testObject.prop2).toEqual(mockValue);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -154,6 +154,19 @@ it("restores mocked object property in jest.restoreAllMocks", () => {
     expect(jest.isMockProp(testObject, "prop2")).toBe(false);
 });
 
+it("does not remock object property", () => {
+    const testObject = { ...mockObject };
+    const mockValue = 99;
+    const spy1 = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
+    expect(testObject.prop1).toEqual(mockValue);
+    const spy2 = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
+    expect(spy2).toBe(spy1);
+    expect(jest.isMockProp(testObject, "prop1")).toBe(true);
+    spy2.mockRestore();
+    expect(testObject.prop1).toEqual("1");
+    expect(jest.isMockProp(testObject, "prop1")).toBe(false);
+});
+
 it.each([undefined, null, 99, "value", true].map(v => [v && typeof v, v]))(
     "does not mock '%s' primitive",
     (_, v: any) => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -87,6 +87,19 @@ it("mocks object property replaces once", () => {
     expect(testObject.prop2).toEqual(4);
 });
 
+it("mocks object multiple properties", () => {
+    const testObject = { ...mockObject };
+    const mockValue = 99;
+    const spy1 = jest.spyOnProp(testObject, "prop1").mockValue(mockValue);
+    expect(testObject.prop1).toEqual(mockValue);
+    jest.spyOnProp(testObject, "prop2").mockValue(mockValue);
+    expect(testObject.prop2).toEqual(mockValue);
+    spy1.mockRestore();
+    expect(jest.isMockProp(testObject, "prop2")).toBe(true);
+    expect(testObject.prop1).toEqual("1");
+    expect(testObject.prop2).toEqual(mockValue);
+});
+
 it("resets mocked object property", () => {
     const testObject = { ...mockObject };
     const mockValue = 99;


### PR DESCRIPTION
# Description

Reuse existing spies when mocking properties

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing
