### PR TITLE
feat: add access type to override unconfigurable properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ The jest object needs to be extended in every test file. This allows mocked prop
 
 Determines if the given object property has been mocked.
 
-#### `jest.spyOnProp(object, propertyName)`
+#### `jest.spyOn(object, propertyName, accessType?)`
 
-**Note**: This is aliased as `jest.spyOn` as of `v1.9.0`, overriding the existing `jest.spyOn` to use `spyOnProp` when spying on a regular object property.
+**Note**: This is originally available as `jest.spyOnProp`, and since `v1.9.0` the existing `jest.spyOn` is overridden to use `spyOnProp` when spying on a regular object property.
 
 Creates a mock property attached to `object[propertyName]` and returns a mock property spy object, which controls all access to the object property. Repeating spying on the same object property will return the same mocked property spy.
 
 **Note**: By default, `spyOnProp` preserves the object property value. If you want to overwrite the original value, you can use `jest.spyOnProp(object, propertyName).mockValue(customValue)` or [`jest.spyOn(object, methodName, accessType?)`](https://jestjs.io/docs/en/jest-object#jestspyonobject-methodname-accesstype) to spy on a getter or a setter.
+
+Use the `set` access type value to ensure unwrittable properties are overridden.
 
 ## Example
 
@@ -113,4 +115,5 @@ it("mocks video length", () => {
 ```
 
 ### Related
+
 * [Spy on JS modules using jest mock](https://www.npmjs.com/package/jest-mock-module)

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -7,7 +7,7 @@ export default {
         noMethodSpy: <K>(p: K): string =>
             `Cannot spy on the property '${p}' because it is a function. Please use \`jest.spyOn\`.`,
         noUnconfigurableSpy: <K>(p: K): string =>
-            `Cannot spy on the property '${p}' because it is not configurable`,
+            `Cannot spy on the property '${p}' because it is not configurable. Use 'set' as the \`accessType\` to overwrite.`,
     },
     warn: {
         noUndefinedSpy: <K>(p: K): string =>

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -14,6 +14,8 @@ exports[`does not mock object getter property 1`] = `"Cannot spy on the property
 
 exports[`does not mock object method property 1`] = `"Cannot spy on the property 'fn1' because it is a function. Please use \`jest.spyOn\`."`;
 
-exports[`does not mock object non-configurable property 1`] = `"Cannot spy on the property 'propUnconfigurable' because it is not configurable"`;
+exports[`does not mock object non-configurable property when using accessType get 1`] = `"Cannot spy on the property 'propUnconfigurable' because it is not configurable. Use 'set' as the \`accessType\` to overwrite."`;
+
+exports[`does not mock object non-configurable property without accessType 1`] = `"Cannot spy on the property 'propUnconfigurable' because it is not configurable. Use 'set' as the \`accessType\` to overwrite."`;
 
 exports[`does not mock object setter property 1`] = `"Cannot spy on the property 'propY' because it is a function. Please use \`jest.spyOn\`."`;

--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -11,7 +11,29 @@ export interface MockProp<T = Spyable, K extends keyof T = keyof T> {
 
 export type SpyMap<T> = Map<T, Map<keyof T, MockProp<T, keyof T>>>;
 
-export type SpyOnProp = <T>(object: T, propName: keyof T) => MockProp<T>;
+// copied from @types/jest
+// see https://github.com/Microsoft/TypeScript/issues/25215
+type Func = (...args: unknown[]) => unknown;
+type NonFunctionPropertyNames<T> = keyof {
+    [K in keyof T as T[K] extends Func ? never : K]: T[K];
+};
+type GetAccessor = "get";
+type SetAccessor = "set";
+export type AnyObject = Record<string, unknown>;
+export type PropertyAccessors<T extends AnyObject, M extends keyof T> =
+    M extends NonFunctionPropertyNames<Required<T>>
+        ? GetAccessor | SetAccessor
+        : never;
+
+export type SpyOnProp = <
+    T extends AnyObject,
+    Key extends keyof T,
+    A extends PropertyAccessors<T, Key> = PropertyAccessors<T, Key>,
+>(
+    object: T,
+    propName: Key,
+    accessType?: A,
+) => MockProp<T, Key>;
 
 export type IsMockProp = <T, K extends keyof T>(
     object: T,


### PR DESCRIPTION
# Description

Resolves #1593 

## Changes

- Add support for replacing unconfigurable properties

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

- Temporarily use configuration instead of `jest.replaceProperty`
